### PR TITLE
Broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ Your projects should contain this flow to maintain similarity across all other p
 
 Create an issue with your idea, approach, your expected outcome and why it's useful to be necessary to be included in this project. For PR, include issue number along with PR template, it's details and compiled output screenshot
 
-All the web related changes should go into [IoT-Spot Website](https://iot-projects-and-scripts.netlify.app/)
+All the web related changes should go into [IoT-Spot Website](https://iot-projects-and-scripts.netlify.app)
 
 
 ## 📖Resources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ Your projects should contain this flow to maintain similarity across all other p
 
 Create an issue with your idea, approach, your expected outcome and why it's useful to be necessary to be included in this project. For PR, include issue number along with PR template, it's details and compiled output screenshot
 
-All the web related changes should go into [IoT-Spot Website]()
+All the web related changes should go into [IoT-Spot Website](https://iot-projects-and-scripts.netlify.app/)
 
 
 ## 📖Resources


### PR DESCRIPTION
The link was actually missing, and not broken.

When added:

<br>

![image](https://user-images.githubusercontent.com/71711222/198706265-1575857f-9184-4b91-9484-68b51dda1b39.png)


<br>

Redirects ->
![image](https://user-images.githubusercontent.com/71711222/198706520-bdd8b359-b64e-428f-a9db-989af8ef8d63.png)

This commit fixes issue #29 